### PR TITLE
updated debian to jessie

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM debian:wheezy-slim
+FROM debian:jessie-slim
 
 ADD ./*.sh /minimeteor/
 


### PR DESCRIPTION
meteor@1.5.2 breaks with debian:wheezy. Also see: https://github.com/meteor/meteor/issues/9068

>  /root/.meteor/packages/meteor-tool/.1.5.2.2ahv3x++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.15' not found (required by /root/.meteor/packages/meteor-tool/.1.5.2.2ahv3x++os.linux.x86_64+web.browser+web.cordova/mt-os.linux.x86_64/dev_bundle/bin/node)
